### PR TITLE
Support use with logback plugin.

### DIFF
--- a/JmxGrailsPlugin.groovy
+++ b/JmxGrailsPlugin.groovy
@@ -125,7 +125,7 @@ class JmxGrailsPlugin {
 	private void exportLogger(ApplicationContext ctx, MBeanExporter exporter, String domain) {
 		if (!ctx.containsBean('log4jMBean')) return
 
-		org.apache.log4j.jmx.HierarchyDynamicMBean hierarchyBean = ctx.log4jMBean
+		def hierarchyBean = ctx.log4jMBean
 		exporter.beans."${domain}:service=log4j,type=configuration" = hierarchyBean
 
 		hierarchyBean.addLoggerMBean org.apache.log4j.Logger.rootLogger.name


### PR DESCRIPTION
Changed typed reference of log4jMBean to be untyped.
The jmx plugin started failing to compile in my project once I added the recently available logback plugin, and excluded log4j.
